### PR TITLE
updrade postgresql image

### DIFF
--- a/TrocSkillHub/docker-compose.yml
+++ b/TrocSkillHub/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
   app:
     build: .


### PR DESCRIPTION
fix: resolve PostgreSQL 18 volume compatibility issue

- Update volume mount to /var/lib/postgresql for PostgreSQL 18+
- Fixes pg_ctlcluster compatibility error
- Aligns with new major-version-specific directory structure