### PR TITLE
TSH-BACK-8-Feat: implement JWT authentication with HttpOnly cookie

### DIFF
--- a/TrocSkillHub/docker-compose.yml
+++ b/TrocSkillHub/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}       
+      JWT_EXPIRATION: ${JWT_EXPIRATION} 
     ports:
       - "8080:8080"
     networks:

--- a/TrocSkillHub/pom.xml
+++ b/TrocSkillHub/pom.xml
@@ -79,6 +79,26 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.83</version>
         </dependency>
+        
+<!-- JWT Dependencies -->
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-api</artifactId>
+        <version>0.11.5</version>
+    </dependency>
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-impl</artifactId>
+        <version>0.11.5</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson, jjwt-orgjson -->
+        <version>0.11.5</version>
+        <scope>runtime</scope>
+    </dependency>
+
     </dependencies>
 
     <build>

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/CorsConfig.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/CorsConfig.java
@@ -1,0 +1,26 @@
+package RNCP.TrocSkillHub.Config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtAuthFIlter.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtAuthFIlter.java
@@ -1,0 +1,59 @@
+
+package RNCP.TrocSkillHub.Config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import RNCP.TrocSkillHub.Services.ImplServices.CustomUserDetailsService;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFIlter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final CustomUserDetailsService userDetailsService;
+    public CorsConfig corsConfig;
+
+    public JwtAuthFIlter(JwtService jwtService, CustomUserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // 3. Extrait le token (on enlève "Bearer ")
+        String token = null;
+
+        if (request.getCookies() != null)
+            for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
+                if ("jwt".equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        // 4. Vérifie le token et authentifie l'utilisateur
+        if (token != null && jwtService.isTokenValid(token)) {
+            String email = jwtService.extractEmail(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails,
+                    null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtService.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtService.java
@@ -1,0 +1,56 @@
+package RNCP.TrocSkillHub.Config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    // Vérifie si le token est encore valide
+    public boolean isTokenValid(String token) {
+        try {
+            return getClaims(token).getExpiration().after(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+}

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/SecurityConfig.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package RNCP.TrocSkillHub.Config;
 
+
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -7,8 +9,11 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 
 import RNCP.TrocSkillHub.Services.ImplServices.CustomUserDetailsService;
 
@@ -18,10 +23,12 @@ public class SecurityConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtAuthFIlter  jwtAuthFilter;
 
-    public SecurityConfig(CustomUserDetailsService customUserDetailsService, PasswordEncoder passwordEncoder) {
+     public SecurityConfig(CustomUserDetailsService customUserDetailsService, PasswordEncoder passwordEncoder, JwtAuthFIlter  jwtAuthFilter) {
         this.customUserDetailsService = customUserDetailsService;
         this.passwordEncoder = passwordEncoder;
+        this.jwtAuthFilter = jwtAuthFilter;
     }
 
     @Bean
@@ -34,23 +41,23 @@ public class SecurityConfig {
         return authenticationManagerBuilder.build();
     }
 
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+            // Not session in serveur (JWT is stateless)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/users").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/users/{id}").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                 // .anyRequest().authenticated()
             )
-            .formLogin(form -> form
-                .usernameParameter("email")
-                .failureHandler((request, response, exception) -> {
-                    response.sendError(401, "Email ou mot de passe incorrect");
-                })
-                .permitAll()
-            );
+
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Controllers/AuthController.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Controllers/AuthController.java
@@ -1,0 +1,62 @@
+package RNCP.TrocSkillHub.Controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.*;
+
+import RNCP.TrocSkillHub.Config.JwtService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtService jwtService;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtService jwtService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> body, HttpServletResponse response) {
+        String email = body.get("email");
+        String password = body.get("password");
+
+        try {
+
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(email, password));
+
+            String token = jwtService.generateToken(email);
+
+            Cookie cookie = new Cookie("jwt", token);
+            cookie.setHttpOnly(false); // False in localhost and True in HTTPS
+            cookie.setPath("/");
+            cookie.setMaxAge(86400);
+
+            response.addCookie(cookie);
+
+            return ResponseEntity.ok(Map.of("message", "Connexion réussie"));
+
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(401).body(Map.of("error", "Email ou mot de passe incorrect"));
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        Cookie cookie = new Cookie("jwt", null);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+        return ResponseEntity.ok(Map.of("message", "Déconnexion réussie"));
+    }
+}

--- a/TrocSkillHub/src/main/resources/application.yaml
+++ b/TrocSkillHub/src/main/resources/application.yaml
@@ -26,3 +26,9 @@ spring:
 logging:
   level:
     org.springframework.security: DEBUG
+
+# JWT Configuration
+jwt:
+  jwt:
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION}


### PR DESCRIPTION
- Add JwtService for token generation and validation
- Add JwtAuthFilter to intercept and validate JWT from HttpOnly cookie
- Add AuthController with /login and /logout endpoints
- Configure SecurityConfig with CORS, stateless session and JWT filter
- Store JWT token in HttpOnly cookie instead of response body
- Add JWT_SECRET and JWT_EXPIRATION environment variables