### PR TITLE
test: add GET /api/users integration tests with Testcontainers and CI pipeline

### DIFF
--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -1,3 +1,5 @@
+
+
 name: TrocSkillHub CI
 
 on:
@@ -32,66 +34,12 @@ jobs:
     name: Test TrocSkillHub
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     defaults:
       run:
         working-directory: ./TrocSkillHub
 
-    env:
-      CI_POSTGRES_DB: ${{ vars.POSTGRES_DB_TEST }}
-      CI_POSTGRES_USER: ${{ vars.POSTGRES_USER_TEST }}
-      CI_POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD_TEST }}
-
-      POSTGRES_USER_TEST: ${{ vars.POSTGRES_USER_TEST }}
-      POSTGRES_PASSWORD_TEST: ${{ vars.POSTGRES_PASSWORD_TEST }}
-      JWT_SECRET: ${{ vars.JWT_SECRET }}
-      JWT_EXPIRATION: ${{ vars.JWT_EXPIRATION }}
-
     steps:
       - uses: actions/checkout@v5
-
-      - name: Contexte CI (diagnostic sans afficher les secrets)
-        run: |
-          echo "event_name=${{ github.event_name }}"
-          echo "repository=${{ github.repository }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}"
-            echo "Si head_repo ≠ repository → PR depuis un fork → ce job ne devrait pas s'exécuter."
-          fi
-
-      - name: Verify secrets (échoue vite si un secret manque)
-        run: |
-          missing=""
-          [ -z "$CI_POSTGRES_DB" ] && missing="$missing POSTGRES_DB_TEST"
-          [ -z "$CI_POSTGRES_USER" ] && missing="$missing POSTGRES_USER_TEST"
-          [ -z "$CI_POSTGRES_PASSWORD" ] && missing="$missing POSTGRES_PASSWORD_TEST"
-          [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
-          [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
-          if [ -n "$missing" ]; then
-            echo "::error::Secrets vides:$missing"
-            echo "Vérifiez : Settings → Secrets and variables → Actions → Repository secrets (onclets Secrets, pas Variables)."
-            echo "Noms exacts : POSTGRES_DB_TEST POSTGRES_USER_TEST POSTGRES_PASSWORD_TEST JWT_SECRET JWT_EXPIRATION"
-            exit 1
-          fi
-
-      - name: Start PostgreSQL
-        run: |
-          docker run -d --name postgres-test \
-            -p 5432:5432 \
-            -e POSTGRES_DB="$CI_POSTGRES_DB" \
-            -e POSTGRES_USER="$CI_POSTGRES_USER" \
-            -e POSTGRES_PASSWORD="$CI_POSTGRES_PASSWORD" \
-            postgres:16
-
-          for i in $(seq 1 45); do
-            if docker exec postgres-test pg_isready -U "$CI_POSTGRES_USER" -d "$CI_POSTGRES_DB" >/dev/null 2>&1; then
-              echo "PostgreSQL is ready."
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs postgres-test
-          exit 1
 
       - uses: actions/setup-java@v5
         with:
@@ -108,6 +56,10 @@ jobs:
           unset SPRING_DATASOURCE_URL || true
           mvn test
 
-      - name: Stop PostgreSQL
-        if: always()
-        run: docker rm -f postgres-test || true
+      - name: Upload Surefire reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trocskillhub-surefire-${{ github.run_number }}
+          path: ./TrocSkillHub/target/surefire-reports/
+          retention-days: 7

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -1,6 +1,6 @@
 # ============================================================
 # CI GITHUB ACTIONS - TROCSKILLHUB
-# ============================================================
+
 
 name: TrocSkillHub CI
 
@@ -74,6 +74,10 @@ jobs:
           [ -z "$SPRING_DATASOURCE_URL_TEST" ] && missing="$missing SPRING_DATASOURCE_URL_TEST"
           [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
           [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing or empty secrets:$missing"
+            exit 1
+          fi
 
       - name: Start PostgreSQL
         env:
@@ -88,6 +92,17 @@ jobs:
             -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             postgres:16
 
+          echo "Waiting for PostgreSQL..."
+          for i in $(seq 1 45); do
+            if docker exec postgres-test pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+              echo "PostgreSQL is ready."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::PostgreSQL did not become ready in time."
+          docker logs postgres-test
+          exit 1
 
       - name: Install Java 21
         uses: actions/setup-java@v5

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -32,6 +32,7 @@ jobs:
     name: Test TrocSkillHub
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     defaults:
       run:
         working-directory: ./TrocSkillHub
@@ -49,6 +50,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Contexte CI (diagnostic sans afficher les secrets)
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "repository=${{ github.repository }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}"
+            echo "Si head_repo ≠ repository → PR depuis un fork → ce job ne devrait pas s'exécuter."
+          fi
+
       - name: Verify secrets (échoue vite si un secret manque)
         run: |
           missing=""
@@ -58,7 +68,9 @@ jobs:
           [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
           [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
           if [ -n "$missing" ]; then
-            echo "::error::Secrets vides :$missing — PR depuis un fork ou secrets non définis sur ce dépôt ?"
+            echo "::error::Secrets vides:$missing"
+            echo "Vérifiez : Settings → Secrets and variables → Actions → Repository secrets (onclets Secrets, pas Variables)."
+            echo "Noms exacts : POSTGRES_DB_TEST POSTGRES_USER_TEST POSTGRES_PASSWORD_TEST JWT_SECRET JWT_EXPIRATION"
             exit 1
           fi
 

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -62,9 +62,9 @@ jobs:
 
       - name: Start PostgreSQL
         env:
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB}}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER}}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: |
           docker run -d --name postgres-test \
             -p 5432:5432 \
@@ -99,8 +99,8 @@ jobs:
 
       - name: Tests
         env:
-          POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
-          POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER}}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
         run: mvn test

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -1,6 +1,6 @@
 # ============================================================
 # CI GITHUB ACTIONS - TROCSKILLHUB
-
+# ============================================================
 
 name: TrocSkillHub CI
 
@@ -74,11 +74,6 @@ jobs:
           [ -z "$SPRING_DATASOURCE_URL_TEST" ] && missing="$missing SPRING_DATASOURCE_URL_TEST"
           [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
           [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
-          if [ -n "$missing" ]; then
-            echo "::error::Missing or empty secrets:$missing"
-            exit 1
-          fi
-
       - name: Start PostgreSQL
         env:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
@@ -91,19 +86,6 @@ jobs:
             -e POSTGRES_USER="$POSTGRES_USER" \
             -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             postgres:16
-
-          echo "Waiting for PostgreSQL..."
-          for i in $(seq 1 45); do
-            if docker exec postgres-test pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
-              echo "PostgreSQL is ready."
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "::error::PostgreSQL did not become ready in time."
-          docker logs postgres-test
-          exit 1
-
       - name: Install Java 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@v5
 
 
+
       - name: Start PostgreSQL
         env:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -58,9 +58,9 @@ jobs:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_DB_TEST: ${{ secrets.POSTGRES_DB_TEST }}
-          POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
-          POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -58,9 +58,9 @@ jobs:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+          POSTGRES_DB_TEST: ${{ secrets.POSTGRES_DB_TEST }}
+          POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
+          POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -63,7 +63,6 @@ jobs:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
-          SPRING_DATASOURCE_URL_TEST: ${{ secrets.SPRING_DATASOURCE_URL_TEST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
         run: |
@@ -71,9 +70,13 @@ jobs:
           [ -z "$POSTGRES_DB" ] && missing="$missing POSTGRES_DB_TEST"
           [ -z "$POSTGRES_USER" ] && missing="$missing POSTGRES_USER_TEST"
           [ -z "$POSTGRES_PASSWORD" ] && missing="$missing POSTGRES_PASSWORD_TEST"
-          [ -z "$SPRING_DATASOURCE_URL_TEST" ] && missing="$missing SPRING_DATASOURCE_URL_TEST"
           [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
           [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing or empty secrets:$missing"
+            exit 1
+          fi
+
       - name: Start PostgreSQL
         env:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
@@ -86,6 +89,19 @@ jobs:
             -e POSTGRES_USER="$POSTGRES_USER" \
             -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             postgres:16
+
+          echo "Waiting for PostgreSQL..."
+          for i in $(seq 1 45); do
+            if docker exec postgres-test pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+              echo "PostgreSQL is ready."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::PostgreSQL did not become ready in time."
+          docker logs postgres-test
+          exit 1
+
       - name: Install Java 21
         uses: actions/setup-java@v5
         with:
@@ -100,7 +116,9 @@ jobs:
 
       - name: Tests
         env:
-          SPRING_DATASOURCE_URL_TEST: ${{ secrets.SPRING_DATASOURCE_URL_TEST }}
+          POSTGRES_HOST_TEST: localhost
+          POSTGRES_PORT_TEST: "5432"
+          POSTGRES_DB_TEST: ${{ secrets.POSTGRES_DB_TEST }}
           POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
           POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -4,9 +4,6 @@
 
 name: TrocSkillHub CI
 
-# ╔════════════════════════════════════════════════════════════╗
-# ║ DECLENCHEURS : Quand la pipeline se lance                  ║
-# ╚════════════════════════════════════════════════════════════╝
 on:
   push:
     branches:
@@ -17,12 +14,8 @@ on:
       - main
       - develop
 
-# ╔════════════════════════════════════════════════════════════╗
-# ║ JOBS : Les taches a executer                               ║
-# ╚════════════════════════════════════════════════════════════╝
 jobs:
  
-  # JOB 1 : Build
   build:
     name: Build TrocSkillHub
     runs-on: ubuntu-latest
@@ -51,7 +44,7 @@ jobs:
         run: mvn clean compile
 
   
-  # JOB 2 : Test (attend que build soit OK)
+
   test:
     name: Test TrocSkillHub
     runs-on: ubuntu-latest
@@ -60,6 +53,21 @@ jobs:
     defaults:
       run:
         working-directory: ./TrocSkillHub
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -d trocskillhubdb_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Code checkout
@@ -77,7 +85,14 @@ jobs:
           path: ~/.m2/repository
           key: trocskillhub-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
-      - name: Unit tests
+      - name: Tests
+        env:
+          SPRING_DATASOURCE_URL_TEST: ${{ secrets.SPRING_DATASOURCE_URL_TEST }}
+          POSTGRES_DB_TEST: trocskillhubdb_test
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+          POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
+          POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: mvn test
 
       - name: Upload errors logs

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
@@ -37,18 +37,30 @@ jobs:
         working-directory: ./TrocSkillHub
 
     env:
-      # Identifiants Postgres (même base que dans application-test.yml)
-      CI_POSTGRES_DB: trocskillhubdb_test
-      CI_POSTGRES_USER: javagolangpyton
-      CI_POSTGRES_PASSWORD: regexgolang
-      # Spring profil test → application-test.yml lit POSTGRES_USER_TEST / POSTGRES_PASSWORD_TEST
-      POSTGRES_USER_TEST: javagolangpyton
-      POSTGRES_PASSWORD_TEST: regexgolang
-      JWT_SECRET: thisIsMysecregtfrdesww233eggtffeeddgkjjhhtdhttebd54ndhdhfhhhshs8877465sbbdm
-      JWT_EXPIRATION: '86400000'
+      CI_POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
+      CI_POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
+      CI_POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+
+      POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
+      POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Verify secrets (échoue vite si un secret manque)
+        run: |
+          missing=""
+          [ -z "$CI_POSTGRES_DB" ] && missing="$missing POSTGRES_DB_TEST"
+          [ -z "$CI_POSTGRES_USER" ] && missing="$missing POSTGRES_USER_TEST"
+          [ -z "$CI_POSTGRES_PASSWORD" ] && missing="$missing POSTGRES_PASSWORD_TEST"
+          [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
+          [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
+          if [ -n "$missing" ]; then
+            echo "::error::Secrets vides :$missing — PR depuis un fork ou secrets non définis sur ce dépôt ?"
+            exit 1
+          fi
 
       - name: Start PostgreSQL
         run: |
@@ -72,7 +84,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -1,6 +1,6 @@
 # ============================================================
 # CI GITHUB ACTIONS - TROCSKILLHUB
-# ============================================================
+
 
 name: TrocSkillHub CI
 
@@ -58,24 +58,6 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@v5
 
-      - name: Verify required secrets
-        env:
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
-        run: |
-          missing=""
-          [ -z "$POSTGRES_DB" ] && missing="$missing POSTGRES_DB_TEST"
-          [ -z "$POSTGRES_USER" ] && missing="$missing POSTGRES_USER_TEST"
-          [ -z "$POSTGRES_PASSWORD" ] && missing="$missing POSTGRES_PASSWORD_TEST"
-          [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
-          [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
-          if [ -n "$missing" ]; then
-            echo "::error::Missing or empty secrets:$missing"
-            exit 1
-          fi
 
       - name: Start PostgreSQL
         env:
@@ -116,9 +98,6 @@ jobs:
 
       - name: Tests
         env:
-          POSTGRES_HOST_TEST: localhost
-          POSTGRES_PORT_TEST: "5432"
-          POSTGRES_DB_TEST: ${{ secrets.POSTGRES_DB_TEST }}
           POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
           POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -54,24 +54,40 @@ jobs:
       run:
         working-directory: ./TrocSkillHub
 
-    services:
-      postgres:
-        image: postgres:16
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v5
+
+      - name: Verify required secrets
         env:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -d trocskillhubdb_test"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+          SPRING_DATASOURCE_URL_TEST: ${{ secrets.SPRING_DATASOURCE_URL_TEST }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+        run: |
+          missing=""
+          [ -z "$POSTGRES_DB" ] && missing="$missing POSTGRES_DB_TEST"
+          [ -z "$POSTGRES_USER" ] && missing="$missing POSTGRES_USER_TEST"
+          [ -z "$POSTGRES_PASSWORD" ] && missing="$missing POSTGRES_PASSWORD_TEST"
+          [ -z "$SPRING_DATASOURCE_URL_TEST" ] && missing="$missing SPRING_DATASOURCE_URL_TEST"
+          [ -z "$JWT_SECRET" ] && missing="$missing JWT_SECRET"
+          [ -z "$JWT_EXPIRATION" ] && missing="$missing JWT_EXPIRATION"
 
-    steps:
-      - name: Code checkout
-        uses: actions/checkout@v5
+      - name: Start PostgreSQL
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+        run: |
+          docker run -d --name postgres-test \
+            -p 5432:5432 \
+            -e POSTGRES_DB="$POSTGRES_DB" \
+            -e POSTGRES_USER="$POSTGRES_USER" \
+            -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            postgres:16
+
 
       - name: Install Java 21
         uses: actions/setup-java@v5
@@ -88,12 +104,15 @@ jobs:
       - name: Tests
         env:
           SPRING_DATASOURCE_URL_TEST: ${{ secrets.SPRING_DATASOURCE_URL_TEST }}
-          POSTGRES_DB_TEST: trocskillhubdb_test
-          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
           POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
           POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
         run: mvn test
+
+      - name: Stop PostgreSQL
+        if: always()
+        run: docker rm -f postgres-test || true
 
       - name: Upload errors logs
         if: failure()

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -38,14 +38,14 @@ jobs:
         working-directory: ./TrocSkillHub
 
     env:
-      CI_POSTGRES_DB: ${{ secrets.POSTGRES_DB_TEST }}
-      CI_POSTGRES_USER: ${{ secrets.POSTGRES_USER_TEST }}
-      CI_POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_TEST }}
+      CI_POSTGRES_DB: ${{ vars.POSTGRES_DB_TEST }}
+      CI_POSTGRES_USER: ${{ vars.POSTGRES_USER_TEST }}
+      CI_POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD_TEST }}
 
-      POSTGRES_USER_TEST: ${{ secrets.POSTGRES_USER_TEST }}
-      POSTGRES_PASSWORD_TEST: ${{ secrets.POSTGRES_PASSWORD_TEST }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
+      POSTGRES_USER_TEST: ${{ vars.POSTGRES_USER_TEST }}
+      POSTGRES_PASSWORD_TEST: ${{ vars.POSTGRES_PASSWORD_TEST }}
+      JWT_SECRET: ${{ vars.JWT_SECRET }}
+      JWT_EXPIRATION: ${{ vars.JWT_EXPIRATION }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tsh-ci.yml
+++ b/.github/workflows/tsh-ci.yml
@@ -1,118 +1,89 @@
-# ============================================================
-# CI GITHUB ACTIONS - TROCSKILLHUB
-
-
 name: TrocSkillHub CI
 
 on:
   push:
     branches:
       - '**'
-
   pull_request:
     branches:
       - main
       - develop
 
 jobs:
- 
   build:
     name: Build TrocSkillHub
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: ./TrocSkillHub
-
     steps:
-      - name: Code checkout
-        uses: actions/checkout@v5
-
-      - name: Install Java 21
-        uses: actions/setup-java@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Maven cache
-        uses: actions/cache@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: trocskillhub-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-
-      - name: Build
-        run: mvn clean compile
-
-  
+      - run: mvn clean compile
 
   test:
     name: Test TrocSkillHub
     runs-on: ubuntu-latest
     needs: build
-
     defaults:
       run:
         working-directory: ./TrocSkillHub
 
+    env:
+      # Identifiants Postgres (même base que dans application-test.yml)
+      CI_POSTGRES_DB: trocskillhubdb_test
+      CI_POSTGRES_USER: javagolangpyton
+      CI_POSTGRES_PASSWORD: regexgolang
+      # Spring profil test → application-test.yml lit POSTGRES_USER_TEST / POSTGRES_PASSWORD_TEST
+      POSTGRES_USER_TEST: javagolangpyton
+      POSTGRES_PASSWORD_TEST: regexgolang
+      JWT_SECRET: thisIsMysecregtfrdesww233eggtffeeddgkjjhhtdhttebd54ndhdhfhhhshs8877465sbbdm
+      JWT_EXPIRATION: '86400000'
+
     steps:
-      - name: Code checkout
-        uses: actions/checkout@v5
-
-
+      - uses: actions/checkout@v5
 
       - name: Start PostgreSQL
-        env:
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB}}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER}}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: |
           docker run -d --name postgres-test \
             -p 5432:5432 \
-            -e POSTGRES_DB="$POSTGRES_DB" \
-            -e POSTGRES_USER="$POSTGRES_USER" \
-            -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            -e POSTGRES_DB="$CI_POSTGRES_DB" \
+            -e POSTGRES_USER="$CI_POSTGRES_USER" \
+            -e POSTGRES_PASSWORD="$CI_POSTGRES_PASSWORD" \
             postgres:16
 
-          echo "Waiting for PostgreSQL..."
           for i in $(seq 1 45); do
-            if docker exec postgres-test pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+            if docker exec postgres-test pg_isready -U "$CI_POSTGRES_USER" -d "$CI_POSTGRES_DB" >/dev/null 2>&1; then
               echo "PostgreSQL is ready."
               exit 0
             fi
             sleep 1
           done
-          echo "::error::PostgreSQL did not become ready in time."
           docker logs postgres-test
           exit 1
 
-      - name: Install Java 21
-        uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Maven cache
-        uses: actions/cache@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: trocskillhub-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Tests
-        env:
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER}}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          JWT_EXPIRATION: ${{ secrets.JWT_EXPIRATION }}
-        run: mvn test
+        run: |
+          unset SPRING_DATASOURCE_URL || true
+          mvn test
 
       - name: Stop PostgreSQL
         if: always()
         run: docker rm -f postgres-test || true
-
-      - name: Upload errors logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: trocskillhub-error-logs-${{ github.run_number }}
-          path: ./TrocSkillHub/target/surefire-reports/
-          retention-days: 7

--- a/TrocSkillHub/.gitignore
+++ b/TrocSkillHub/.gitignore
@@ -36,4 +36,4 @@ build/
 .env
 
 ### computer cache 
- ../.DS_Store
+**/.DS_Store

--- a/TrocSkillHub/docker-compose.test.yml
+++ b/TrocSkillHub/docker-compose.test.yml
@@ -1,13 +1,13 @@
 services:
   postgres-test:
     image: postgres:16
-    container_name: postgres-test
+    container_name: trocskillhubdatabase_test
     environment:
       POSTGRES_DB: ${POSTGRES_DB_TEST}
       POSTGRES_USER: ${POSTGRES_USER_TEST}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD_TEST}
     ports:
-      - "5434:5432"
+      - "${POSTGRES_PORT_TEST}:5432"
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     networks:
@@ -18,21 +18,6 @@ services:
       timeout: 5s
       retries: 5
 
-  app-test:
-    build: .
-    container_name: spring-boot-test
-    depends_on:
-      postgres-test:
-        condition: service_healthy
-    environment:
-      SPRING_PROFILES_ACTIVE: test
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-test:5432/${POSTGRES_DB_TEST}
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER_TEST}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD_TEST}
-    ports:
-      - "8081:8080"
-    networks:
-      - troc-test-network
 
 networks:
   troc-test-network:

--- a/TrocSkillHub/docker-compose.yml
+++ b/TrocSkillHub/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   postgres:
     image: postgres:16
-    container_name: postgres-dev
+    container_name: trocskillhubdatabase
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "5433:5432"
+      - "${POSTGRES_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -20,7 +20,7 @@ services:
 
   app:
     build: .
-    container_name: spring-boot
+    container_name: trocskillhubservice
     depends_on:
       postgres:
         condition: service_healthy
@@ -31,7 +31,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}       
       JWT_EXPIRATION: ${JWT_EXPIRATION} 
     ports:
-      - "8080:8080"
+      - "${APP_PORT}:8080"
     networks:
       - troc-network
 

--- a/TrocSkillHub/pom.xml
+++ b/TrocSkillHub/pom.xml
@@ -68,6 +68,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 <!-- Lombok -->
         <dependency>

--- a/TrocSkillHub/src/main/resources/application-test.yml
+++ b/TrocSkillHub/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL_TEST}
+    url: jdbc:postgresql://localhost:5432/trocskillhubdb_test
     username: ${POSTGRES_USER_TEST}
     password: ${POSTGRES_PASSWORD_TEST}
 

--- a/TrocSkillHub/src/main/resources/application-test.yml
+++ b/TrocSkillHub/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5434/trocskillhubdb_test
+    url: ${SPRING_DATASOURCE_URL_TEST}
     username: ${POSTGRES_USER_TEST}
     password: ${POSTGRES_PASSWORD_TEST}
 

--- a/TrocSkillHub/src/main/resources/application-test.yml
+++ b/TrocSkillHub/src/main/resources/application-test.yml
@@ -1,8 +1,9 @@
 spring:
   datasource:
+   
     url: jdbc:postgresql://localhost:5432/trocskillhubdb_test
-    username: ${POSTGRES_USER_TEST}
-    password: ${POSTGRES_PASSWORD_TEST}
+    username: ${POSTGRES_USER_TEST:test}
+    password: ${POSTGRES_PASSWORD_TEST:test}
 
  
   jpa:
@@ -23,3 +24,8 @@ spring:
 logging:
   level:
     org.springframework.security: DEBUG
+
+
+jwt:
+  secret: ${JWT_SECRET:test-jwt-secret-ci-only-needs-minimum-32-chars-for-hs256}
+  expiration: ${JWT_EXPIRATION:86400000}

--- a/TrocSkillHub/src/main/resources/application.yaml
+++ b/TrocSkillHub/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: TrocSkillHub
   
   datasource:
-    url: jdbc:postgresql://postgres:5432/trocskillhubdb
+    url: ${SPRING_DATASOURCE_URL}
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
+++ b/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
@@ -29,12 +29,11 @@ import jakarta.servlet.http.Cookie;
 @Testcontainers
 class UsersApiIntegrationTest {
 
-    @Container
+    @SuppressWarnings("resource")
+	@Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
-            .withDatabaseName("trocskillhubdb_test")
-            .withUsername("test")
-            .withPassword("test");
-
+            .withDatabaseName("trocskillhubdb_test");
+          
     @DynamicPropertySource
     static void registerDataSource(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);

--- a/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
+++ b/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
@@ -1,0 +1,80 @@
+package RNCP.TrocSkillHub.Users;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UsersApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Cookie jwtCookie;
+
+    @BeforeEach
+    void setUp() throws Exception {
+    
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "nom": "Dupont",
+                      "prenom": "Jean",
+                      "email": "jean.dupont@test.fr",
+                      "password": "Password1!",
+                      "city": "Paris",
+                      "country": "France"
+                    }
+                    """));
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "email": "jean.dupont@test.fr",
+                      "password": "Password1!"
+                    }
+                    """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        jwtCookie = loginResult.getResponse().getCookie("jwt");
+    }
+
+    @Test
+    void getAllUsers_withJwt_returnsUsersWithNames() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users").cookie(jwtCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].firstName").value("Jean"))
+                .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].lastName").value("Dupont"))
+                .andReturn();
+    
+       
+        System.out.println("Réponse GET /api/users :\n" + result.getResponse().getContentAsString());
+    }
+
+    @Test
+    void getAllUsers_withoutJwt_returns403() throws Exception {
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isForbidden());
+            
+                
+    }
+}

--- a/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
+++ b/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
@@ -12,15 +12,35 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import jakarta.servlet.http.Cookie;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Testcontainers
 class UsersApiIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+            .withDatabaseName("trocskillhubdb_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void registerDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
This PR adds integration tests for the GET /api/users endpoint (JWT authentication via cookie, expected HTTP responses) and sets up a reliable GitHub Actions CI pipeline that does not require PostgreSQL secrets: the test database is started by Testcontainers during test execution.

Main changes
Integration tests (UsersApiIntegrationTest)
@SpringBootTest + @AutoConfigureMockMvc + test profile
Flow: POST /api/auth/register → POST /api/auth/login → jwt cookie → GET /api/users
getAllUsers_withJwt_returnsUsersWithNames: HTTP 200, JSON array, firstName / lastName for jean.dupont@test.fr
getAllUsers_withoutJwt_returns403: access denied without JWT
Testcontainers (PostgreSQL)
postgres:16-alpine container started by JUnit (@Testcontainers, @Container)
JDBC URL / username / password injected into Spring via @DynamicPropertySource
Flyway runs against this ephemeral database (classpath:db/migration)
No longer required: separate docker run postgres step or GitHub secrets for the test database in CI
