### PR TITLE
feat(auth): support Authorization Bearer token for cross-browser auth

### DIFF
--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtAuthFIlter.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Config/JwtAuthFIlter.java
@@ -44,6 +44,11 @@ public class JwtAuthFIlter extends OncePerRequestFilter {
         // 3. Extrait le token (on enlève "Bearer ")
         String token = null;
 
+        String authHeader = request.getHeader("Authorization");
+if (authHeader != null && authHeader.startsWith("Bearer ")) {
+    token = authHeader.substring(7);
+}
+
         if (request.getCookies() != null)
             for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
                 if ("jwt".equals(cookie.getName())) {

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Controllers/AuthController.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Controllers/AuthController.java
@@ -77,7 +77,8 @@ public ResponseEntity<?> register(@RequestBody Map<String, String> body, HttpSer
 
         return ResponseEntity.ok(Map.of(
                 "message", "Inscription réussie",
-                "id", savedUser.getId() 
+                "id", savedUser.getId(),
+                "token", token
         ));
 
     } catch (Exception e) {
@@ -107,7 +108,9 @@ public ResponseEntity<?> register(@RequestBody Map<String, String> body, HttpSer
     
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                    .body(Map.of("message", "Connexion réussie"));
+                    .body(Map.of("message", "Connexion réussie",
+                        "token", token
+                    ));
     
         } catch (AuthenticationException e) {
             return ResponseEntity.status(401)

--- a/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
+++ b/TrocSkillHub/src/test/java/RNCP/TrocSkillHub/Users/UsersApIntegrationTest.java
@@ -20,8 +20,11 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import com.jayway.jsonpath.JsonPath;
 
-import jakarta.servlet.http.Cookie;
+
+
+
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -44,56 +47,47 @@ class UsersApiIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private Cookie jwtCookie;
 
-    @BeforeEach
-    void setUp() throws Exception {
-    
-        mockMvc.perform(post("/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
-                    {
-                      "nom": "Dupont",
-                      "prenom": "Jean",
-                      "email": "jean.dupont@test.fr",
-                      "password": "Password1!",
-                      "city": "Paris",
-                      "country": "France"
-                    }
-                    """));
+    private String jwtToken;
 
-        MvcResult loginResult = mockMvc.perform(post("/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
-                    {
-                      "email": "jean.dupont@test.fr",
-                      "password": "Password1!"
-                    }
-                    """))
-                .andExpect(status().isOk())
-                .andReturn();
+ @BeforeEach
+void setUp() throws Exception {
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                  "nom": "Dupont",
+                  "prenom": "Jean",
+                  "email": "jean.dupont@test.fr",
+                  "password": "Password1!",
+                  "city": "Paris",
+                  "country": "France"
+                }
+                """));
+    MvcResult loginResult = mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                  "email": "jean.dupont@test.fr",
+                  "password": "Password1!"
+                }
+                """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").exists())
+            .andReturn();
 
-        jwtCookie = loginResult.getResponse().getCookie("jwt");
-    }
+            String body = loginResult.getResponse().getContentAsString();
+    jwtToken = JsonPath.read(body, "$.token");
 
-    @Test
-    void getAllUsers_withJwt_returnsUsersWithNames() throws Exception {
-        MvcResult result = mockMvc.perform(get("/users").cookie(jwtCookie))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].firstName").value("Jean"))
-                .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].lastName").value("Dupont"))
-                .andReturn();
-    
-       
-        System.out.println("Réponse GET /users :\n" + result.getResponse().getContentAsString());
-    }
+}
+@Test
+void getAllUsers_withJwt_returnsUsersWithNames() throws Exception {
 
-    @Test
-    void getAllUsers_withoutJwt_returns403() throws Exception {
-        mockMvc.perform(get("/users"))
-                .andExpect(status().isForbidden());
-            
-                
-    }
+    mockMvc.perform(get("/users")
+            .header("Authorization", "Bearer " + jwtToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].firstName").value("Jean"))
+            .andExpect(jsonPath("$[?(@.email == 'jean.dupont@test.fr')].lastName").value("Dupont"));
+}
 }


### PR DESCRIPTION
Read JWT from Authorization header in JwtAuthFilter, return token in login/register responses, and update integration tests to use Bearer.