### PR TITLE
docs: audit cybersécurité (OWASP) et RGPD

### DIFF
--- a/AUDIT-RGPD.md
+++ b/AUDIT-RGPD.md
@@ -1,0 +1,161 @@
+# Audit RGPD : TrocSkillHub Back-end
+
+> Branche : `audit-cyber-rgpd`
+> Périmètre : entités JPA (`Models/`), migrations Flyway, controllers/services, configuration (`application.yaml`), points de log, sous-traitants.
+> Rôle du projet : l'exploitant de TrocSkillHub est **responsable de traitement** ; l'équipe technique fournit les **moyens techniques**. L'audit vérifie que les moyens techniques des obligations existent dans le code. Aucune modification de code.
+> Ce document est un audit technique de conformité, **pas un avis juridique**. Les décisions marquées « responsable / DPO » relèvent du responsable de traitement.
+
+## Verdict
+
+**Bloquant.** Un défaut du flux de réinitialisation de mot de passe permet la prise de contrôle d'un compte sans connaître le code envoyé par email, donc l'accès non autorisé à l'ensemble des données personnelles d'un utilisateur (art. 32). À corriger avant toute mise en production. S'ajoutent plusieurs écarts majeurs (journalisation de données personnelles en clair, absence de purge des comptes, code de reset faible).
+
+Récapitulatif : **1 bloquant, 5 majeurs, 7 mineurs.**
+
+---
+
+## Findings
+
+### [bloquant] Réinitialisation de mot de passe : le « token » est l'id séquentiel de la demande, le code n'est jamais revérifié à l'étape reset
+
+- **Fichier** : `TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Services/ImplServices/PasswordResetServiceImpl.java:104` et `:108-145` ; `PasswordResetRequest` id auto-incrément (`V12__create_password_reset_request_table.sql:4`)
+- **Risque** : `verifyCode` renvoie `prr.getId().toString()` comme reset token, et `resetPassword` ne contrôle que `used`/`expires_at` avant de changer le mot de passe. Aucune liaison prouvant que le code à 4 chiffres a été validé. L'id étant un `BIGSERIAL` séquentiel donc devinable, un attaquant peut, dans la fenêtre de 15 min suivant n'importe quelle demande de reset (déclenchable par lui), appeler `/auth/password-reset/reset` avec un id deviné et définir un nouveau mot de passe sans jamais recevoir le code email. Résultat : prise de contrôle de compte et accès à toutes les données personnelles (identité, email, téléphone, adresse, parcours). Violation de la confidentialité du traitement, **art. 32**.
+- **Qui agit** : responsable de traitement (via l'équipe technique).
+- **Correction attendue** : lier l'étape reset à une vérification réussie du code (token secret aléatoire non devinable, généré uniquement après `verifyCode` OK, distinct de l'id ; marquer la demande « vérifiée » et n'autoriser reset que dans cet état) ; ne jamais utiliser l'id de ligne comme secret.
+
+### [majeur] Adresses email des personnes journalisées en clair à chaque opération de reset
+
+- **Fichier** : `Controllers/PasswordResetController.java:31,35,47,49,52` ; `Services/ImplServices/PasswordResetServiceImpl.java:52,66,74,80,85,91,99,103,140` ; `ImplServices/SimpleEmailService.java:36,38`
+- **Risque** : l'email (donnée identifiante) est écrit en INFO/WARN à chaque request/verify/reset, y compris pour des emails inexistants (révèle une tentative sur un email donné). Ces journaux persistent et sont potentiellement transmis à un système de logs tiers. Défaut de minimisation appliqué aux logs, **art. 32 et art. 5-1-c**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : ne pas journaliser l'email en clair (identifiant interne ou valeur tronquée/hachée), abaisser le niveau, définir une durée de conservation des logs.
+
+### [majeur] Mode debug SMTP activé : le corps de l'email, donc le code de reset, est écrit sur la sortie standard
+
+- **Fichier** : `application.yaml:33` (`mail.properties.mail.debug: true`) ; corps contenant le code : `SimpleEmailService.java:32`
+- **Risque** : `mail.debug=true` fait imprimer par JavaMail l'intégralité du dialogue SMTP, dont le texte du message qui contient le code de réinitialisation en clair et l'email du destinataire. Un secret d'authentification et une donnée personnelle se retrouvent dans les logs applicatifs. **art. 32**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : `mail.debug=false` en production ; s'assurer qu'aucun secret ne transite par les logs.
+
+### [majeur] Journalisation verbeuse en production (Spring Security DEBUG, show-sql) exposant potentiellement des données
+
+- **Fichier** : `application.yaml:42-44` (`org.springframework.security: DEBUG`) et `:14` (`show-sql: true`), `:18` (`format-sql: true`) ; idem `application-test.yml:24-26,12`
+- **Risque** : le niveau DEBUG de Spring Security et `show-sql` augmentent fortement les traces liées à l'authentification et aux requêtes SQL sur `users`, `education`, `experience`, `project` (les valeurs restent en `?` par défaut, mais le paramétrage de trace Hibernate peut les révéler). Configuration non adaptée à un traitement de données personnelles en production, **art. 32**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : niveau INFO/WARN en prod, `show-sql: false`, séparer clairement config dev et prod.
+
+### [majeur] Aucune durée de conservation ni purge des comptes utilisateurs
+
+- **Fichier** : entité `User` (`Models/User.java`, champs `created_at`/`updated_at` présents mais non exploités pour une purge) ; seul scheduler existant : `Config/PasswordResetCleanupScheduler.java:27` (purge uniquement les demandes de reset expirées)
+- **Risque** : les profils de type CV (identité, coordonnées, parcours détaillé) sont conservés sans limite de durée ni mécanisme d'inactivité. Aucun code ne supprime ou n'anonymise les comptes dormants. Manquement à la limitation de conservation, **art. 5-1-e**.
+- **Qui agit** : responsable de traitement (fixer la durée) + technique (implémenter la purge/anonymisation).
+- **Correction attendue** : définir une durée (ex X ans après dernière activité via `updated_at`), implémenter un job de purge/anonymisation, prévoir une information préalable de l'utilisateur.
+
+### [majeur] Code de réinitialisation faible : 4 chiffres générés avec java.util.Random
+
+- **Fichier** : `Services/ImplServices/PasswordResetServiceImpl.java:29,57` (`new Random()`, `String.format("%04d", random.nextInt(10000))`)
+- **Risque** : espace de seulement 10 000 valeurs, générateur non cryptographique (`java.util.Random` prédictible). Le garde-fou est `max-attempts=5` (`application.yaml:58`) et un rate limiter en mémoire (3 requêtes/30 min par email, non partagé entre instances). Combiné au finding bloquant, la robustesse du reset est insuffisante, **art. 32**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : utiliser `SecureRandom`, code plus long (6 à 8 caractères), verrouillage après échecs, rate limiting persistant.
+
+### [mineur] Données de personnes (fictives) et hash commités dans les migrations de seed
+
+- **Fichier** : `db/migration/V2__seed_add_data_users.sql:6-8` ; `V3__add_ada_lovelace_user.sql:5`
+- **Risque** : noms, emails `@example.fr` et hash bcrypt insérés en base à chaque déploiement. Les personnes sont manifestement fictives (Jean Martin, Sophie Lefebvre, Ada Lovelace) et les emails en `example.fr` sont réservés aux tests, donc pas de donnée réelle exposée. Reste une mauvaise pratique : ces comptes de démonstration seront créés en production et les hash sont versionnés.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : ne pas charger de comptes de démonstration en production (profil de migration séparé), retirer les hash du dépôt.
+
+### [mineur] Dump SQL commité à la racine
+
+- **Fichier** : `TrocSkillHub/backup_avant_flyway.sql:80-81` (bloc `COPY ... FROM stdin` vide) ; `:26,46,60` (propriétaire `MoSa`)
+- **Risque** : le dump ne contient aucune ligne de données personnelles (le `COPY` est vide), donc pas de fuite de données utilisateurs. Il révèle le nom du propriétaire de base `MoSa` et le schéma. Impact faible.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : ne pas versionner de dumps de base ; si conservé, le sortir du dépôt applicatif.
+
+### [mineur] JWT non révocable côté serveur, et token renvoyé dans le corps de réponse
+
+- **Fichier** : `Controllers/AuthController.java:121-130` (logout efface seulement le cookie) ; `:111-113` (login renvoie `token` dans le body) ; `JwtService.java` (aucune denylist)
+- **Risque** : à la déconnexion le JWT reste valide jusqu'à expiration (24 h), sans liste de révocation. Le token est aussi renvoyé dans le corps JSON alors que le cookie est `httpOnly`, ce qui invite le front à le stocker côté client et annule la protection XSS du cookie. Défaut de maîtrise des accès, **art. 32**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : mécanisme de révocation (denylist / rotation / durée courte + refresh), ne pas exposer le token dans le corps si le cookie httpOnly est utilisé.
+
+### [mineur] /auth/register n'applique pas la politique de mot de passe et imprime la stacktrace
+
+- **Fichier** : `Controllers/AuthController.java:63` (`encode(password)` sans `validatePasswordStrength`) ; `:85` (`e.printStackTrace()`)
+- **Risque** : `/auth/register` encode le mot de passe sans contrôle de robustesse, alors que `POST /users` le valide (`UserServiceImpl.java:56`). Incohérence affaiblissant la sécurité des identifiants. `printStackTrace` écrit une trace technique sur stderr. **art. 32**, impact limité.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : appliquer la même validation, remplacer `printStackTrace` par un log maîtrisé sans donnée personnelle.
+
+### [mineur] Exposition du nom complet et de la localisation de tous les utilisateurs aux membres authentifiés
+
+- **Fichier** : `Controllers/UserController.java:35-40` ; `DTOs/UserPublicResponseDTO.java:6-13` ; `SecurityConfig.java:54` (`GET /users` authenticated)
+- **Risque** : `GET /users` renvoie `firstName`, `lastName`, `city`, `country`, compétences et besoins de tous les utilisateurs à tout membre connecté. Le scoping des données sensibles est correct (email, téléphone, adresse ne sortent que sur `/users/me`, avec `address` en WRITE_ONLY), mais l'exposition du nom de famille complet plus la ville pourrait être minimisée pour la seule finalité de mise en relation. **art. 5-1-c**.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : évaluer si le nom de famille complet est nécessaire dans la liste interne ; sinon réduire (prénom + initiale, ou ville sans nom complet).
+
+### [mineur] Champs libres pouvant capter des données sensibles (art. 9), sans encadrement
+
+- **Fichier** : `Models/User.java:51-52` (`description` TEXT) ; `Models/Project.java:17` (`description` TEXT), `:20` (`links`) ; `Models/Experience.java:14-17` ; `Models/Education.java:14-17`
+- **Risque** : les champs libres (bio, description de projet, employeur, établissement) peuvent révéler des opinions, engagements, appartenance syndicale, santé, etc. (**art. 9**). Rien dans le code ne les filtre ni n'avertit l'utilisateur. Risque inhérent à un profil de type CV.
+- **Qui agit** : responsable de traitement / DPO.
+- **Correction attendue** : mention d'information invitant à ne pas renseigner de données sensibles ; décision juridique sur la base légale et le traitement de ces champs.
+
+### [mineur, à confirmer] Actuator présent
+
+- **Fichier** : `pom.xml:38` (`spring-boot-starter-actuator`) ; aucune section `management` dans `application.yaml`
+- **Risque** : la dépendance Actuator est incluse. Sans configuration `management.endpoints.web.exposure`, seuls `health` et `info` sont exposés en HTTP, et `anyRequest().authenticated()` (`SecurityConfig.java:60`) les protège. Pas d'exposition de config/env constatée.
+- **Qui agit** : responsable de traitement.
+- **Correction attendue** : garder l'exposition minimale, protéger explicitement `/actuator/**`.
+
+---
+
+## Points conformes constatés (à conserver)
+
+- Mots de passe hachés (BCrypt via `PasswordConfig`ᵃ, code de reset stocké haché, colonne `code_hash`). *(ᵃ l'audit sécurité relève un hachage Argon2id sur les mots de passe utilisateur ; à réconcilier selon la configuration effective de `PasswordConfig`.)*
+- `@JsonIgnore` sur `password` (`User.java:35`) : le hash n'est jamais sérialisé.
+- Secrets externalisés en variables d'environnement (datasource, jwt, mail) ; `.env` gitignoré et non suivi par git ; aucun secret en dur dans docker-compose.
+- **Droit à l'effacement techniquement présent** : `DELETE /users/me` scindé sur l'utilisateur authentifié, cascade JPA `CascadeType.ALL` + `orphanRemoval` sur education/experience/project/userKnowledge (`User.java:70-80`) et `ON DELETE CASCADE` sur password_reset_request (V12).
+- Purge des demandes de reset expirées (`PasswordResetCleanupScheduler.java:27`, toutes les heures).
+- Endpoints scindés sur l'utilisateur courant (`/me`) via `resolveOwnId` : pas d'accès aux données d'un autre par id dans l'URL.
+- Réponses anti-énumération sur `/password-reset/request` (message générique).
+- CORS en allowlist par variable d'environnement, pas de wildcard ; SMTP par défaut `smtp.mail.ovh.net` (OVH, UE probable).
+
+---
+
+## Cartographie des données personnelles touchées
+
+| Donnée | Finalité | Base de conservation constatée dans le code | Destinataire |
+|---|---|---|---|
+| Nom, prénom (User.first_name/last_name) | Identité du profil, mise en relation | Illimitée (aucune purge) | Tous membres authentifiés (liste), hébergeur/BDD |
+| Email (User.email) | Authentification, contact, reset | Illimitée | Propre profil (/me), serveur SMTP, **journaux applicatifs (en clair)** |
+| Mot de passe haché (User.password) | Authentification | Illimitée | Base uniquement (non sérialisé) |
+| Adresse, ville, pays | Localisation pour mise en relation | Illimitée | ville/pays exposés à tous ; adresse au propre profil |
+| Téléphone (phone_number) | Contact | Illimitée | Propre profil (/me) |
+| Photo (picture, bytea) | Illustration du profil | Illimitée | Propre profil |
+| Bio / descriptions libres | Présentation, portfolio | Illimitée | Champ libre pouvant capter de l'art. 9 |
+| Parcours : formations, expériences, projets | Profil de compétences type CV | Illimitée (cascade suppression avec le compte) | Propre profil ; potentielles données art. 9 |
+| Compétences et besoins (UserKnowledge) | Matching d'échange de compétences | Illimitée | Tous membres authentifiés |
+| Code de reset + tentatives (PasswordResetRequest) | Réinitialisation de mot de passe | Purge horaire après expiration (15 min) | Base + email + **logs (mode debug SMTP)** |
+| Rôle (users.role, V4) | Contrôle d'accès admin | Illimitée | Base |
+
+Sous-traitants ultérieurs (**art. 28**) : fournisseur SMTP (OVH par défaut, localisation UE à confirmer), hébergeur (Docker/PostgreSQL, localisation UE à déterminer). À contractualiser.
+
+---
+
+## À porter au registre / à la doc du responsable
+
+- Finalités et base légale du traitement (mise en relation, gestion de profils/comptes) et des champs libres susceptibles de contenir de l'art. 9 ; mention d'information invitant à ne pas y saisir de données sensibles.
+- Durées de conservation à définir : comptes utilisateurs (aucune actuellement, **art. 5-1-e**), logs applicatifs, sauvegardes ; mécanisme de purge/anonymisation des comptes inactifs à implémenter.
+- Modalités d'exercice des droits : effacement (`DELETE /users/me` existe), rectification (`PUT/PATCH /users/me`), accès (`GET /users/me`), et portabilité **art. 20** : pas d'export structuré dédié, seul `/me` renvoie un JSON du profil ; prévoir un export réutilisable si nécessaire.
+- Sous-traitants (**art. 28**) : fournisseur SMTP (OVH par défaut, localisation UE à confirmer et à contractualiser), hébergeur (Docker/PostgreSQL, localisation UE à déterminer), avec clauses art. 28 et vérification d'absence de transfert hors UE (**art. 44+**).
+- Politique de journalisation : exclure email, code de reset et tout secret des logs ; désactiver `mail.debug`, `show-sql` et `security: DEBUG` en production ; durée de conservation des logs.
+- Politique de gestion des secrets et de révocation des tokens (JWT), robustesse et cycle de vie du code de reset.
+
+---
+
+## Top 3 à traiter en priorité
+
+1. **[bloquant] Reset de mot de passe contournable** (token = id séquentiel, code jamais revérifié) → prise de contrôle de compte (art. 32).
+2. **Email et code de reset journalisés en clair**, aggravés par `mail.debug=true`, `show-sql=true` et Spring Security en DEBUG (art. 32).
+3. **Aucune durée de conservation ni purge des comptes utilisateurs** (art. 5-1-e).
+
+Donnée la plus à risque : l'ensemble du profil accessible via un compte pris en main par le contournement du reset ; l'email est l'élément le plus exposé (identifiant journalisé en clair et pivot de l'attaque).

--- a/AUDIT-SECURITE.md
+++ b/AUDIT-SECURITE.md
@@ -1,0 +1,129 @@
+# Audit sécurité (OWASP) : TrocSkillHub Back-end
+
+> Branche : `audit-cyber-rgpd`
+> Périmètre : API REST Spring Boot (controllers, config sécurité JWT, services, repositories), configuration (`application.yaml`), migrations Flyway.
+> Méthode : audit statique selon OWASP API Security Top 10 (2023) et OWASP Top 10 web. Aucune modification de code. Chaque finding est vérifié dans le code et assorti d'un scénario d'exploitation.
+
+## Verdict
+
+**Bloquant exploitable.** Une prise de contrôle de compte à distance est possible sans authentification via le flux de réinitialisation de mot de passe. Corrections obligatoires avant toute mise en production.
+
+Récapitulatif : **1 bloquant, 5 majeurs, 3 mineurs.**
+
+---
+
+## Findings
+
+### [bloquant] Réinitialisation de mot de passe contournable : jeton = identifiant séquentiel, le code n'est jamais vérifié à /reset (OWASP API1 — BOLA / API2 — Broken Authentication)
+
+- **Fichier** : `TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Services/ImplServices/PasswordResetServiceImpl.java:104` (`return prr.getId().toString();`) et `:107-145` (`resetPassword`)
+- **Faille** : le « reset token » renvoyé par `/verify` est simplement la clé primaire auto-incrémentée (`Long`, `GenerationType.IDENTITY`) de la ligne `password_reset_request`. À l'étape `/reset`, `resetPassword` fait `Long.parseLong(resetToken)` puis `findById(prrId)` et se contente de vérifier `!used && !expired` avant de changer le mot de passe de `prr.getUser()`. Aucune revérification du code à 4 chiffres, ni de l'email, ni de propriété du jeton. Le secret réel (le code envoyé par email à la victime) n'intervient pas dans `/reset`.
+- **Scénario d'exploitation** : un attaquant non authentifié appelle `POST /auth/password-reset/request {"email":"victime@x.com"}` (réponse générique, mais une ligne est créée pour la victime, `used=false`, valable 15 min). Les ids étant séquentiels, il appelle ensuite `POST /auth/password-reset/reset {"resetToken":"<N>","newPassword":"Pirate1!","confirmPassword":"Pirate1!"}` en énumérant quelques valeurs proches de l'id courant. Dès qu'il touche la ligne non utilisée et non expirée, le mot de passe de la victime est remplacé. Prise de contrôle de n'importe quel compte (y compris un futur admin), sans jamais connaître le code à 4 chiffres.
+- **Correction attendue** : le jeton remis après `/verify` doit être un secret aléatoire fort (≥128 bits, `SecureRandom`, stocké haché), non devinable, distinct de l'id. `/reset` doit exiger ce jeton opaque, vérifier qu'il correspond à une demande en état « code validé », à usage unique, lié à l'utilisateur. Ne jamais exposer la PK comme jeton.
+
+### [majeur] Rôle admin totalement non appliqué + fonctions privilégiées ouvertes (catégories/knowledges) (OWASP API5 — Broken Function Level Authorization / API3)
+
+- **Fichier** : `SecurityConfig.java:46-52` ; `CustomUserDetailsService.java:28-29` ; `CategoryController.java:32` ; `KnowledgeController.java:37-56` ; `Models/User.java` (aucun champ `role` mappé)
+- **Faille** : trois problèmes cumulés. (1) `CustomUserDetailsService.loadUserByUsername` appelle `getGrantedAuthorities(null)` en dur : tout utilisateur, admin compris, reçoit une liste d'autorités VIDE. (2) L'entité `User` ne mappe pas la colonne `role` ajoutée en V4 : le rôle n'est jamais chargé. (3) `SecurityConfig` ne contient aucun `hasRole`/`@PreAuthorize`. Conséquence : `POST /categories` est en `permitAll()` (création sans authentification) et `POST/PUT/DELETE /knowledges` sont en `authenticated()` seulement. Catégories et knowledges sont des données de référence PARTAGÉES par tous les profils.
+- **Scénario d'exploitation** : un utilisateur lambda authentifié (ou anonyme pour les catégories) appelle `DELETE /knowledges/12` et supprime une compétence de référence utilisée dans les profils d'autres utilisateurs, ou pollue le référentiel via `POST /categories` sans compte. Le rôle `ADMIN` prévu (V4) n'a aucun effet. Corruption/altération de données partagées, déni de service fonctionnel.
+- **Correction attendue** : mapper `role` dans l'entité, charger les vraies autorités dans `CustomUserDetailsService`, réserver `POST/PUT/DELETE /knowledges` et `POST /categories` à `hasRole("ADMIN")`.
+
+### [majeur] Aucune limitation de débit / anti-bruteforce sur /auth/login (OWASP API2 — Broken Authentication)
+
+- **Fichier** : `AuthController.java:90-119` ; `RateLimiter.java` (utilisé uniquement dans `PasswordResetController.java:30`)
+- **Faille** : `login` n'a aucune protection anti-bruteforce. Le `RateLimiter` n'est branché que sur `/auth/password-reset/request`. De plus ce `RateLimiter` est une `HashMap` en mémoire non thread-safe (accès concurrents non synchronisés), non partagée entre instances et remise à zéro à chaque redémarrage ; ses constantes en dur (3 / 30 min) ignorent `password-reset.max-attempts` configuré.
+- **Scénario d'exploitation** : un attaquant lance du credential stuffing ou du bruteforce sur `POST /auth/login` sans aucune borne (ni délai, ni verrouillage, ni captcha). Compromission de comptes à mots de passe faibles.
+- **Correction attendue** : limiter les tentatives de login (par IP + par compte) avec un store partagé (Redis/bucket), verrouillage temporaire, et rendre le RateLimiter thread-safe/distribué.
+
+### [majeur] Code de réinitialisation faible : 4 chiffres générés avec java.util.Random (OWASP API2 — Broken Authentication)
+
+- **Fichier** : `PasswordResetServiceImpl.java:29` (`new Random()`), `:57` (`String.format("%04d", random.nextInt(10000))`)
+- **Faille** : le code de reset n'a que 10 000 valeurs possibles et est produit par `java.util.Random`, un PRNG non cryptographique et prédictible (seed dérivable). Même hors du bloquant ci-dessus, l'espace est trop petit.
+- **Scénario d'exploitation** : si le flux `/verify` était corrigé pour être la seule voie, un attaquant qui déclenche un reset sur un compte cible peut tenter les 10 000 codes ; la borne `maxAttempts=5` par demande ralentit mais reste contournable en enchaînant plusieurs demandes. Prédiction possible via l'observation d'autres sorties du `Random`.
+- **Correction attendue** : utiliser `SecureRandom`, code d'au moins 6 chiffres (idéalement token alphanumérique long), durcir le comptage d'échecs global.
+
+### [majeur] Journalisation verbeuse et fuite de données sensibles en logs (OWASP API8 / A09 — Security Logging)
+
+- **Fichier** : `application.yaml:14` (`show-sql: true`), `:18` (`format-sql: true`), `:33` (`mail.debug: true`), `:42-44` (`org.springframework.security: DEBUG`) ; `PasswordResetController.java:60,62` (log du reset token) ; `PasswordResetServiceImpl` et `SimpleEmailService` (emails loggés partout)
+- **Faille** : en configuration de production `show-sql`/`format-sql` déversent les requêtes SQL, `spring.security` est en `DEBUG`, `mail.debug=true` imprime tout le dialogue SMTP (donc le code de reset et l'email en clair), et le controller logue le « reset token » et les adresses email à chaque étape.
+- **Scénario d'exploitation** : quiconque a accès aux logs (exploitant, agrégateur, fuite de fichier log) récupère des jetons de reset et des données personnelles (emails), ce qui, combiné au bloquant, facilite encore la prise de compte.
+- **Correction attendue** : `show-sql:false`, `mail.debug:false`, niveau `INFO`/`WARN` en prod, ne jamais logger jetons/codes/emails en clair.
+
+### [majeur] Authentification par cookie JWT avec CSRF désactivé et SameSite=None (OWASP API8 — Security Misconfiguration / A01) — à confirmer dynamiquement
+
+- **Fichier** : `SecurityConfig.java:38` (`csrf.disable()`) ; `JwtAuthFIlter.java:52-58` (token lu depuis le cookie `jwt`) ; `AuthController.java:101-107` (cookie `sameSite=None`, `secure`, `httpOnly`)
+- **Faille** : le filtre accepte le JWT depuis un cookie envoyé automatiquement par le navigateur, la protection CSRF est désactivée et le cookie de login est en `SameSite=None`. Les endpoints d'écriture (`PUT/PATCH/DELETE /users/me`) deviennent des cibles CSRF potentielles.
+- **Scénario d'exploitation** : un site malveillant visité par une victime connectée déclenche une requête cross-site vers l'API ; le navigateur joint le cookie `jwt`. L'exploitation réelle est atténuée par le préflight CORS sur les corps JSON et la restriction d'origines de `CorsConfig` : à confirmer selon la valeur réelle de `CORS_ALLOWED_ORIGINS`. Reste une faiblesse de conception.
+- **Correction attendue** : soit n'utiliser que l'en-tête `Authorization: Bearer` (pas de cookie d'auth), soit activer une protection CSRF (double-submit token) et `SameSite=Strict/Lax`.
+
+### [mineur] /auth/register contourne la politique de mot de passe et ne valide aucune entrée (OWASP API8 / A04 — Insecure Design)
+
+- **Fichier** : `AuthController.java:44-89` (corps `Map<String,String>`, `save` direct, `encode(password)`), aucun `@Valid` ni jakarta-validation dans le projet
+- **Faille** : `register` prend un `Map` brut, n'appelle pas `validatePasswordStrength` (contrairement à `POST /users` via `createUser`), ne valide ni le format email ni la présence des champs, et n'a pas de `@Valid`. Un mot de passe vide/faible ou un email invalide est accepté. `NullPointerException` possible si des champs manquent (capturée en 500 avec `printStackTrace()`).
+- **Correction attendue** : DTO validé (`@NotBlank`, `@Email`, `@Size`), appliquer `validatePasswordStrength` sur register, supprimer `printStackTrace`.
+
+### [mineur] Absence de révocation de JWT et jeton renvoyé dans le corps (OWASP API2)
+
+- **Fichier** : `JwtService.java:23-30` (HS256, pas d'issuer/audience) ; `AuthController.java:111-113` (`token` dans le body) ; `AuthController.java:121-130` (`logout` efface seulement le cookie)
+- **Faille** : `logout` ne fait qu'expirer le cookie ; aucune liste de révocation. Le token est aussi renvoyé dans le corps JSON, donc un jeton volé reste valable jusqu'à expiration et le logout ne l'invalide pas. Pas de rotation après reset de mot de passe.
+- **Correction attendue** : liste de révocation/blacklist (jti) ou tokens courts + refresh, invalidation des sessions après changement de mot de passe.
+
+### [mineur] Cookie de register non Secure / sans SameSite + @CrossOrigin en dur (OWASP API8)
+
+- **Fichier** : `AuthController.java:71-77` (cookie `jwt` de register sans `secure`, sans `sameSite`) ; `UserController.java:25` (`@CrossOrigin(origins="http://localhost:5173")` en dur)
+- **Faille** : le cookie posé par `register` n'est ni `Secure` ni `SameSite`, contrairement à celui de `login`. Le `@CrossOrigin` en dur fige une origine de dev dans le code, en doublon avec `CorsConfig`.
+- **Correction attendue** : cookie `Secure`+`SameSite` cohérent, retirer l'origine en dur au profit de la config centralisée.
+
+---
+
+## Surface d'attaque (endpoints audités)
+
+| Route | Méthode | Rôle/scope attendu | Statut protection |
+|---|---|---|---|
+| `/auth/register` | POST | public | Validation d'entrée et politique mot de passe absentes (mineur) |
+| `/auth/login` | POST | public | Pas de rate limiting (majeur) |
+| `/auth/logout` | POST | public | Pas de révocation réelle (mineur) |
+| `/auth/me` | GET | token cookie | Signature vérifiée (OK) |
+| `/auth/password-reset/request` | POST | public | Anti-énumération OK, rate limiter faible/en mémoire |
+| `/auth/password-reset/verify` | POST | public | Renvoie la PK comme jeton (design cassé) |
+| `/auth/password-reset/reset` | POST | public | **BLOQUANT** : ne vérifie pas le code, jeton = id séquentiel → ATO |
+| `/users` | GET | authenticated | Renvoie `UserPublicResponseDTO` (pas de PII d'autrui) : sûr |
+| `/users` | POST | authenticated | Passe par `createUser` (validation OK) : sûr |
+| `/users/me` | GET/PUT/PATCH/DELETE | authenticated | Id résolu depuis le token, pas d'id dans l'URL : pas de BOLA, sûr |
+| `/categories` | GET | public | OK ; `POST /categories` en permitAll → BFLA (majeur) |
+| `/knowledges`, `/knowledges/{id}` | GET | public | OK ; `POST/PUT/DELETE` authenticated sans rôle → BFLA (majeur) |
+| `/actuator/**` | — | authenticated | `anyRequest().authenticated()`, seul `/health` par défaut : risque faible |
+
+---
+
+## Points sûrs notables (à ne pas régresser)
+
+- **Pas de BOLA sur les données de profil** : toutes les écritures utilisateur passent par `/users/me` avec l'id résolu depuis le token ; aucun endpoint d'écriture prenant un id pour user/education/experience/project. Éducation/expérience/projet synchronisés en collections liées au propriétaire.
+- **Pas de mass assignment de privilège** : `UserRequestDTO` ne contient ni `role` ni `id` ; `UserMapper.toEntity` ignore explicitement `id` et les collections.
+- **Hachage Argon2id** (paramètres 16/32/1/19456/2) via `PasswordConfig`. Code de reset stocké haché.
+- **Aucune injection SQL/JPQL** : aucun `@Query`, uniquement des méthodes dérivées Spring Data paramétrées.
+- `password` annoté `@JsonIgnore` ; `UserResponseDTO` (email/téléphone) renvoyé uniquement sur le profil propre ; `GET /users` public sans PII.
+- **Secrets externalisés** en variables d'environnement (aucun secret en dur dans le code, docker-compose ni la CI) ; `.env` gitignoré.
+- Anti-énumération sur `/password-reset/request` et sur `login` (messages génériques).
+- `ddl-auto: validate` (pas de `update`/`create` en prod).
+- `backup_avant_flyway.sql` versionné mais **sans aucune ligne de données** (COPY vide) : divulgation de structure uniquement. Seed V2/V3 = comptes fictifs avec hash bcrypt factices (l'app hache en Argon2, ces comptes ne peuvent pas se connecter).
+
+---
+
+## Non vérifiable statiquement (à traiter en DAST / pentest / revue infra)
+
+- Force réelle du `JWT_SECRET` et valeur de `JWT_EXPIRATION` en prod (fournis par l'environnement).
+- Valeur réelle de `CORS_ALLOWED_ORIGINS` en prod (détermine l'exploitabilité concrète du risque CSRF).
+- Exposition réseau effective d'Actuator derrière le reverse proxy et endpoints Actuator éventuellement activés par variable d'environnement.
+- Contenu réel de la base seedée en prod (les migrations V2/V3 s'exécutent-elles hors test ?).
+- Exploitabilité CSRF end-to-end (dépend des content-types acceptés et du préflight CORS).
+
+---
+
+## Top 3 à traiter en priorité
+
+1. **[bloquant] Reset de mot de passe contournable** (API1/API2) — jeton = id séquentiel, code jamais revérifié → account takeover à distance sans auth.
+2. **Rôle admin jamais chargé/appliqué + `POST /categories` permitAll et `/knowledges` mutables par tout authentifié** (API5) — altération de données partagées.
+3. **Aucun anti-bruteforce sur `/auth/login`** (API2).
+
+Flux le plus exposé : `POST /auth/password-reset/reset`.


### PR DESCRIPTION
## Objet

Ajout de deux comptes rendus d'**audit statique** du projet, sans aucune modification du code applicatif. Le diff se limite à deux fichiers Markdown à la racine.

- `AUDIT-SECURITE.md` — audit sécurité selon **OWASP API Security Top 10 (2023)**.
- `AUDIT-RGPD.md` — audit de conformité **RGPD**.

Chaque finding est vérifié dans le code (`fichier:ligne`), classé par gravité et assorti d'un scénario / d'un article RGPD et d'une correction attendue. Aucune correction n'est appliquée : ce sont des recommandations.

## ⚠️ Verdict : BLOQUANT des deux côtés

Les deux audits convergent sur une **prise de contrôle de compte à distance non authentifiée** via le flux de réinitialisation de mot de passe.

## Synthèse sécurité (OWASP)

**Verdict : bloquant exploitable.** 1 bloquant, 5 majeurs, 3 mineurs.

Top 3 :
1. **[bloquant]** Reset de mot de passe contournable (API1/API2) — `verifyCode` renvoie la clé primaire séquentielle (`prr.getId()`) comme « token », et `resetPassword` ne revérifie jamais le code à 4 chiffres. Un attaquant déclenche un reset sur la victime puis devine l'id séquentiel pour changer son mot de passe sans recevoir le code email → **account takeover**.
2. **[majeur]** Rôle admin jamais chargé/appliqué (`CustomUserDetailsService` passe `null` en autorités, entité `User` ne mappe pas `role`) + `POST /categories` en `permitAll` et `/knowledges` mutables par tout authentifié (API5) → altération de données partagées.
3. **[majeur]** Aucun anti-bruteforce sur `POST /auth/login` (API2) ; le `RateLimiter` maison n'est branché que sur le reset et n'est pas thread-safe.

Autres majeurs : code de reset à 4 chiffres via `java.util.Random` ; journalisation verbeuse (`show-sql`, `mail.debug`, Security DEBUG, tokens et emails en clair) ; cookie JWT + CSRF désactivé + SameSite=None.

## Synthèse RGPD

**Verdict : bloquant.** 1 bloquant, 5 majeurs, 7 mineurs.

Top 3 :
1. **[bloquant]** Même flux de reset → accès non autorisé à l'ensemble des données personnelles d'un compte (art. 32).
2. **[majeur]** Email et code de reset journalisés en clair, aggravés par `mail.debug=true` (dialogue SMTP complet dans les logs), `show-sql=true` et Spring Security en DEBUG (art. 32).
3. **[majeur]** Aucune durée de conservation ni purge des comptes utilisateurs — profils de type CV conservés sans limite (art. 5-1-e).

## Points forts relevés (à ne pas régresser)

Pas de BOLA sur les données de profil (écritures via `/users/me`, id résolu depuis le token), pas de mass assignment de privilège, hachage Argon2id, aucune injection SQL/JPQL, `password` en `@JsonIgnore`, secrets externalisés en variables d'environnement + `.env` gitignoré, droit à l'effacement présent (`DELETE /users/me` avec cascade), anti-énumération sur reset et login, CORS en allowlist. Le `backup_avant_flyway.sql` versionné ne contient aucune donnée (COPY vide) et les seeds V2/V3 sont des comptes fictifs.

## Portée

Audit **statique** uniquement. Les vérifications runtime (force réelle du `JWT_SECRET`, valeur de `CORS_ALLOWED_ORIGINS`, exposition Actuator, exécution des seeds en prod, exploitabilité CSRF end-to-end) sont listées dans « Non vérifiable statiquement ». Les décisions juridiques (registre, durées de conservation, base légale, DPA SMTP/hébergeur, transferts hors UE) relèvent du responsable de traitement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
