### PR TITLE
refactor: unify user foreign key naming and enforce referential integ…

### DIFF
--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Education.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Education.java
@@ -25,7 +25,7 @@ public class Education {
 
     // Relation with User
     @ManyToOne
-    @JoinColumn(name = "users_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // Constructor required by JPA

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Experience.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Experience.java
@@ -25,7 +25,7 @@ public class Experience {
 
     // Relation with User
     @ManyToOne
-    @JoinColumn(name = "users_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // Constructor required by JPA

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Project.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Models/Project.java
@@ -28,7 +28,7 @@ public class Project {
 
     // Relation with User
     @ManyToOne
-    @JoinColumn(name = "users_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // Constructor required by JPA

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Repositories/PasswordResetRequestRepository.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Repositories/PasswordResetRequestRepository.java
@@ -3,6 +3,8 @@ package RNCP.TrocSkillHub.Repositories;
 import RNCP.TrocSkillHub.Models.PasswordResetRequest;
 import RNCP.TrocSkillHub.Models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -13,5 +15,6 @@ import java.util.Optional;
 public interface PasswordResetRequestRepository extends JpaRepository<PasswordResetRequest, Long> {
     Optional<PasswordResetRequest> findTopByUserOrderByCreatedAtDesc(User user);
 
-    List<PasswordResetRequest> findByExpiresAtBefore(LocalDateTime time);
+    @Query("SELECT p FROM PasswordResetRequest p WHERE p.expiresAt < :time")
+    List<PasswordResetRequest> findByExpiresAtBefore(@Param("time") LocalDateTime time);
 }

--- a/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Repositories/UserRepository.java
+++ b/TrocSkillHub/src/main/java/RNCP/TrocSkillHub/Repositories/UserRepository.java
@@ -4,14 +4,24 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import RNCP.TrocSkillHub.Models.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-    Boolean existsByEmail(String email);
-    List<User> findByCity(String city);
-    List<User> findByCountry(String country);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmail(@Param("email") String email);
+
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN TRUE ELSE FALSE END FROM User u WHERE u.email = :email")
+    Boolean existsByEmail(@Param("email") String email);
+
+    @Query("SELECT u FROM User u WHERE u.city = :city")
+    List<User> findByCity(@Param("city") String city);
+
+    @Query("SELECT u FROM User u WHERE u.country = :country")
+    List<User> findByCountry(@Param("country") String country);
 }

--- a/TrocSkillHub/src/main/resources/db/migration/V13__rename_users_id_to_user_id.sql
+++ b/TrocSkillHub/src/main/resources/db/migration/V13__rename_users_id_to_user_id.sql
@@ -1,0 +1,7 @@
+-- V13__rename_users_id_to_user_id.sql
+-- Align the foreign key column name on the user_id convention already used by
+-- user_knowledge and password_reset_request.
+
+ALTER TABLE education  RENAME COLUMN users_id TO user_id;
+ALTER TABLE experience RENAME COLUMN users_id TO user_id;
+ALTER TABLE project    RENAME COLUMN users_id TO user_id;

--- a/TrocSkillHub/src/main/resources/db/migration/V14__add_user_fk_on_profile_child_tables.sql
+++ b/TrocSkillHub/src/main/resources/db/migration/V14__add_user_fk_on_profile_child_tables.sql
@@ -1,0 +1,31 @@
+-- V14__add_user_fk_on_profile_child_tables.sql
+-- V10 created these columns without any constraint: rows could reference a
+-- missing user, and deleting a user in raw SQL left orphans behind.
+
+-- Orphans are unreachable from the API (these entities are only loaded through
+-- the User collections), so they are safe to drop before enforcing the FK.
+DELETE FROM education  WHERE user_id IS NULL OR user_id NOT IN (SELECT id FROM "users");
+DELETE FROM experience WHERE user_id IS NULL OR user_id NOT IN (SELECT id FROM "users");
+DELETE FROM project    WHERE user_id IS NULL OR user_id NOT IN (SELECT id FROM "users");
+
+ALTER TABLE education  ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE experience ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE project    ALTER COLUMN user_id SET NOT NULL;
+
+ALTER TABLE education
+    ADD CONSTRAINT fk_education_user
+    FOREIGN KEY (user_id) REFERENCES "users"(id) ON DELETE CASCADE;
+
+ALTER TABLE experience
+    ADD CONSTRAINT fk_experience_user
+    FOREIGN KEY (user_id) REFERENCES "users"(id) ON DELETE CASCADE;
+
+ALTER TABLE project
+    ADD CONSTRAINT fk_project_user
+    FOREIGN KEY (user_id) REFERENCES "users"(id) ON DELETE CASCADE;
+
+-- PostgreSQL does not index the referencing side of a foreign key: without
+-- these, each cascading user deletion scans the whole child table.
+CREATE INDEX idx_education_user_id  ON education(user_id);
+CREATE INDEX idx_experience_user_id ON experience(user_id);
+CREATE INDEX idx_project_user_id    ON project(user_id);


### PR DESCRIPTION
…rity

Rename users_id to user_id on education, experience and project so every child table follows one convention, then add the NOT NULL constraints, cascading foreign keys and indexes that V10 never created. Repository lookups are rewritten as explicit JPQL with named parameters.